### PR TITLE
Replace sorted() with .sort()

### DIFF
--- a/ple/games/flappybird/__init__.py
+++ b/ple/games/flappybird/__init__.py
@@ -322,7 +322,7 @@ class FlappyBird(base.PyGameWrapper):
             if p.x > self.player.pos_x:
                 pipes.append((p, p.x - self.player.pos_x))
 
-        sorted(pipes, key=lambda p: p[1])
+        pipes.sort(key=lambda p: p[1])
 
         next_pipe = pipes[1][0]
         next_next_pipe = pipes[0][0]


### PR DESCRIPTION
Sorted() returns the sorted list, rather than sorting it in-place. As it was, the sorted() command was doing nothing; I replace it with an in-place sort, as expected by the following lines,