### PR TITLE
Fixed bug in flappy bird

### DIFF
--- a/ple/games/flappybird/__init__.py
+++ b/ple/games/flappybird/__init__.py
@@ -423,7 +423,7 @@ class FlappyBird(base.PyGameWrapper):
             self.lives -= 1
 
         # went above the screen
-        if self.player.pos_y < 0:
+        if self.player.pos_y <= 0:
             self.lives -= 1
 
         self.player.update(dt)

--- a/ple/games/flappybird/__init__.py
+++ b/ple/games/flappybird/__init__.py
@@ -423,7 +423,7 @@ class FlappyBird(base.PyGameWrapper):
             self.lives -= 1
 
         # went above the screen
-        if self.player.pos_y < -self.player.height:
+        if self.player.pos_y < 0:
             self.lives -= 1
 
         self.player.update(dt)


### PR DESCRIPTION
It really messed up my research with DQN RL variations, because it is possible to bypass pipe over the screen.

See screenshot: http://www.evernote.com/l/AClrdjOMAFBLSLm1-ZvYqa-63AOtriZ9NoI/
This state gives reward = 1.0 (notice bird partially over pipe)

player height 24, but it is enough to be at position -20 to bypass pipe.

Can you please give me rights to push patch to repo? I am planning to work with your repo and I could find more bugs.